### PR TITLE
Switch to the v3 Codecov action like Traction Service uses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,4 +108,6 @@ jobs:
         run: |
           python -m pytest -vx
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Attempt to fix the Codecov uploads that occur during test running in GitHub Actions.
