### PR TITLE
Y24-021: Post-decode message validation

### DIFF
--- a/lab_share_lib/processing/rabbit_message.py
+++ b/lab_share_lib/processing/rabbit_message.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 from lab_share_lib.constants import (
     LOGGER_NAME_RABBIT_MESSAGES,
     RABBITMQ_HEADER_KEY_ENCODER_TYPE,
@@ -6,6 +7,7 @@ from lab_share_lib.constants import (
     RABBITMQ_HEADER_KEY_VERSION,
     RABBITMQ_HEADER_VALUE_ENCODER_TYPE_DEFAULT,
 )
+from lab_share_lib.rabbit.avro_encoder import AvroEncoderBase
 
 LOGGER = logging.getLogger(__name__)
 MESSAGE_LOGGER = logging.getLogger(LOGGER_NAME_RABBIT_MESSAGES)
@@ -30,7 +32,7 @@ class RabbitMessage:
     def schema_version(self):
         return self.headers[RABBITMQ_HEADER_KEY_VERSION]
 
-    def decode(self, possible_encoders):
+    def decode(self, possible_encoders: List[AvroEncoderBase]) -> AvroEncoderBase:
         exceptions = []
         for encoder in possible_encoders:
             try:
@@ -38,7 +40,7 @@ class RabbitMessage:
                 self._decoded_list = list(encoder.decode(self.encoded_body, self.schema_version))
                 if encoder.encoder_type == "binary":
                     MESSAGE_LOGGER.info(f"Decoded binary message body:\n{self._decoded_list}")
-                return
+                return encoder
             except ValueError as ex:
                 LOGGER.debug(f"Failed to decode message with encoder class '{type(encoder).__name__}': {ex}")
                 exceptions.append(ex)

--- a/lab_share_lib/processing/rabbit_message.py
+++ b/lab_share_lib/processing/rabbit_message.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List
 from lab_share_lib.constants import (
+    ENCODER_TYPE_BINARY,
     LOGGER_NAME_RABBIT_MESSAGES,
     RABBITMQ_HEADER_KEY_ENCODER_TYPE,
     RABBITMQ_HEADER_KEY_SUBJECT,
@@ -38,7 +39,7 @@ class RabbitMessage:
             try:
                 LOGGER.debug(f"Attempting to decode message with encoder class '{type(encoder).__name__}'.")
                 self._decoded_list = list(encoder.decode(self.encoded_body, self.schema_version))
-                if encoder.encoder_type == "binary":
+                if encoder.encoder_type == ENCODER_TYPE_BINARY:
                     MESSAGE_LOGGER.info(f"Decoded binary message body:\n{self._decoded_list}")
                 return encoder
             except ValueError as ex:

--- a/lab_share_lib/rabbit/avro_encoder.py
+++ b/lab_share_lib/rabbit/avro_encoder.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from io import StringIO, BytesIO
 from typing import Any, Iterable, List, NamedTuple, Optional
 
+from fastavro.validation import validate
 import fastavro
 
 from lab_share_lib.rabbit.schema_registry import RESPONSE_KEY_SCHEMA, RESPONSE_KEY_VERSION
@@ -44,6 +45,9 @@ class AvroEncoderBase(ABC):
 
     def _schema_version(self, schema_response):
         return schema_response[RESPONSE_KEY_VERSION]
+
+    def validate(self, data_obj: Any, schema_version: str) -> None:
+        validate(data_obj, self._schema(self._schema_response(schema_version)))
 
 
 class AvroEncoderJson(AvroEncoderBase):

--- a/tests/processing/test_rabbit_message_processor.py
+++ b/tests/processing/test_rabbit_message_processor.py
@@ -2,6 +2,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from fastavro.validation import ValidationError
+from logging import ERROR
+
 from lab_share_lib.constants import (
     RABBITMQ_HEADER_KEY_SUBJECT,
     RABBITMQ_HEADER_KEY_VERSION,
@@ -27,12 +30,6 @@ HEADERS = {
     RABBITMQ_HEADER_KEY_VERSION: "3",
 }
 MESSAGE_BODY = "Body"
-
-
-@pytest.fixture
-def logger():
-    with patch("lab_share_lib.processing.rabbit_message_processor.LOGGER") as logger:
-        yield logger
 
 
 @pytest.fixture(autouse=True)
@@ -134,17 +131,15 @@ def test_process_message_decodes_the_message_with_binary_encoding(subject, rabbi
     rabbit_message_binary.return_value.decode.assert_called_once_with(build_avro_encoders.return_value)
 
 
-def test_process_message_handles_exception_during_decode(subject, logger, rabbit_message):
+def test_process_message_handles_exception_during_decode(subject, rabbit_message, caplog):
     rabbit_message.return_value.decode.side_effect = KeyError()
     result = subject.process_message(HEADERS, MESSAGE_BODY)
 
     assert result is False
-    logger.error.assert_called_once()
-    error_log = logger.error.call_args.args[0]
-    assert "unrecoverable" in error_log.lower()
+    assert any("unrecoverable" in log.message.lower() and log.levelno == ERROR for log in caplog.records)
 
 
-def test_process_message_handles_transient_error_from_schema_registry(subject, logger, rabbit_message):
+def test_process_message_handles_transient_error_from_schema_registry(subject, rabbit_message, caplog):
     # We have mocked out the decode method.  The AvroEncoder speaks to the schema registry
     # which could raise this error type so we'll just mock it on the decode method.
     error_message = "Schema registry unreachable"
@@ -153,31 +148,57 @@ def test_process_message_handles_transient_error_from_schema_registry(subject, l
     with pytest.raises(TransientRabbitError):
         subject.process_message(HEADERS, MESSAGE_BODY)
 
-    logger.error.assert_called_once()
-    error_log = logger.error.call_args.args[0]
-    assert "transient" in error_log.lower()
-    assert error_message in error_log
+    assert any("transient" in log.message.lower() and log.levelno == ERROR for log in caplog.records)
 
 
-def test_process_message_rejects_rabbit_message_with_multiple_messages(subject, logger, rabbit_message):
+def test_process_message_rejects_rabbit_message_with_multiple_messages(subject, rabbit_message, caplog):
     rabbit_message.return_value.contains_single_message = False
     result = subject.process_message(HEADERS, MESSAGE_BODY)
 
     assert result is False
-    logger.error.assert_called_once()
-    error_log = logger.error.call_args.args[0]
-    assert "multiple" in error_log.lower()
+    assert any("multiple" in log.message.lower() and log.levelno == ERROR for log in caplog.records)
 
 
-def test_process_message_rejects_rabbit_message_with_unrecognised_subject(subject, logger, rabbit_message):
+def test_process_message_calls_validate_on_used_encoder(subject, rabbit_message):
+    message = rabbit_message.return_value
+    encoder = MagicMock()
+    message.decode.return_value = encoder
+
+    subject.process_message(HEADERS, MESSAGE_BODY)
+
+    encoder.validate.assert_called_with(message.message, message.schema_version)
+
+
+def test_process_message_returns_false_when_validate_raises_validation_error(subject, rabbit_message):
+    message = rabbit_message.return_value
+    encoder = MagicMock()
+    message.decode.return_value = encoder
+    encoder.validate.side_effect = ValidationError("Test")
+
+    result = subject.process_message(HEADERS, MESSAGE_BODY)
+
+    assert result is False
+
+
+def test_process_message_logs_error_when_validate_raises_validation_error(subject, rabbit_message, caplog):
+    message = rabbit_message.return_value
+    encoder = MagicMock()
+    message.decode.return_value = encoder
+    validation_error = ValidationError("Test")
+    encoder.validate.side_effect = validation_error
+
+    subject.process_message(HEADERS, MESSAGE_BODY)
+
+    assert any(str(validation_error) in log.message and log.levelno == ERROR for log in caplog.records)
+
+
+def test_process_message_rejects_rabbit_message_with_unrecognised_subject(subject, rabbit_message, caplog):
     wrong_subject = "random-subject"
     rabbit_message.return_value.subject = wrong_subject
     result = subject.process_message(HEADERS, MESSAGE_BODY)
 
     assert result is False
-    logger.error.assert_called_once()
-    error_log = logger.error.call_args.args[0]
-    assert wrong_subject in error_log
+    assert any(wrong_subject in log.message and log.levelno == ERROR for log in caplog.records)
 
 
 @pytest.mark.parametrize("return_value", [True, False])

--- a/tests/rabbit/test_avro_encoder.py
+++ b/tests/rabbit/test_avro_encoder.py
@@ -102,6 +102,16 @@ class TestCommonAvroEncoderFunctionality:
         subject = request.getfixturevalue(encoder_name)
         assert subject._schema_version(SCHEMA_RESPONSE) == 7
 
+    @pytest.mark.parametrize("encoder_name", ENCODER_NAMES)
+    def test_validate_calls_fastavro_validate(self, encoder_name, fastavro, request):
+        subject = request.getfixturevalue(encoder_name)
+
+        with patch("lab_share_lib.rabbit.avro_encoder.validate") as validate:
+            data_obj = {"key": "value"}
+            subject.validate(data_obj, "5")
+
+        validate.assert_called_once_with(data_obj, fastavro.parse_schema.return_value)
+
 
 class TestAvroEncoderJson:
     def test_encoder_type_returns_json(self, json_subject):


### PR DESCRIPTION
Closes https://github.com/sanger/tol-lab-share/issues/73

#### Changes proposed in this pull request

- Validate every single-object decoded message against its schema before passing it to a processor.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  